### PR TITLE
docs: Change location to display routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,30 +9,36 @@ before registering any routes so that it can collect all of them.
 ## Example
 
 ```js
+const fastify = require('fastify')()
 
 fastify.register(require('fastify-routes'))
 
-fastify.get('/hello', opts, (request, reply) => {
+fastify.get('/hello', {}, (request, reply) => {
   reply.send({ hello: 'world' })
 })
 
-console.log(fastify.routes)
-
-/* will output a Map with entries:
-{
-  '/hello': {
-    get: {
-      method: 'GET',
-      url: '/hello',
-      schema: Object,
-      handler: <Function>,
-      prefix: <String>,
-      logLevel: <String>,
-      bodyLimit: <Number>
+fastify.listen(3000, (err, address) => {
+  if (err) {
+    console.error(err)
+    return
+  }
+  console.log(fastify.routes)
+  /* will output a Map with entries:
+  {
+    '/hello': {
+      get: {
+        method: 'GET',
+        url: '/hello',
+        schema: Object,
+        handler: <Function>,
+        prefix: <String>,
+        logLevel: <String>,
+        bodyLimit: <Number>
+      }
     }
   }
-}
-*/
+  */
+})
 
 ```
 


### PR DESCRIPTION
Was changed the location of display routes, because sometimes when `console.log` is called, the `avvio.after` cannot register the route yet. To prevent copy/paste deception.