### PR TITLE
Allow more than route to be registered for the same url and method

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,38 @@
 [![Known Vulnerabilities](https://snyk.io/test/github/fastify/fastify-routes/badge.svg)](https://snyk.io/test/github/fastify/fastify-routes)
 [![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)](https://standardjs.com/)
 
-This plugin decorates a Fastify instance with `routes`, which is a [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) of registered routes. Note that you have to register this plugin
-before registering any routes so that it can collect all of them.
+This plugin decorates a Fastify instance with `routes`, which is a [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) of registered routes. Note that you have to register this plugin before registering any routes so that it can collect all of them.
+
+## Data Structure
+
+The `fastify.routes` Map has a key for each path any route has been registered, which points to an array of routes registered on that path. There can be more than one route for a given path if there are multiple routes added with different methods or different constraints.
+
+```js
+  {
+    '/hello': [
+      {
+        method: 'GET',
+        url: '/hello',
+        schema: { ... },
+        handler: Function,
+        prefix: String,
+        logLevel: String,
+        bodyLimit: Number,
+        constraints: undefined,
+      },
+      {
+        method: 'POST',
+        url: '/hello',
+        schema: { ... },
+        handler: Function,
+        prefix: String,
+        logLevel: String,
+        bodyLimit: Number,
+        constraints: { ... },
+      }
+    ]
+  }
+```
 
 ## Example
 
@@ -27,8 +57,8 @@ fastify.listen(3000, (err, address) => {
   console.log(fastify.routes)
   /* will output a Map with entries:
   {
-    '/hello': {
-      get: {
+    '/hello': [
+      {
         method: 'GET',
         url: '/hello',
         schema: Object,
@@ -37,11 +67,10 @@ fastify.listen(3000, (err, address) => {
         logLevel: <String>,
         bodyLimit: <Number>
       }
-    }
+    ]
   }
   */
 })
-
 ```
 
 ## License

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/fastify/fastify-routes#readme",
   "devDependencies": {
-    "fastify": "^3.0.0",
+    "fastify": "^3.17.0",
     "pre-commit": "^1.2.2",
     "snazzy": "^9.0.0",
     "standard": "^16.0.0",

--- a/plugin.js
+++ b/plugin.js
@@ -6,20 +6,15 @@ function fastifyRoutes (fastify, options, next) {
   fastify.decorate('routes', new Map())
 
   fastify.addHook('onRoute', (routeOptions) => {
-    const { method, schema, url, logLevel, prefix, bodyLimit, handler } = routeOptions
-    const _method = Array.isArray(method) ? method : [method]
+    const { url } = routeOptions
 
-    _method.forEach(method => {
-      const key = method.toLowerCase()
-      const route = { method, schema, url, logLevel, prefix, bodyLimit, handler }
+    let routeListForUrl = fastify.routes.get(url)
+    if (!routeListForUrl) {
+      routeListForUrl = []
+      fastify.routes.set(url, routeListForUrl)
+    }
 
-      if (fastify.routes.has(url)) {
-        const current = fastify.routes.get(url)
-        fastify.routes.set(url, Object.assign(current, { [key]: route }))
-      } else {
-        fastify.routes.set(url, { [key]: route })
-      }
-    })
+    routeListForUrl.push(routeOptions)
   })
 
   next()


### PR DESCRIPTION
Newer fastify versions support route constraints, which means that a path & method don't uniquely identify a route anymore. Fastify will allow multiple route handlers to be added for the same path and method if they have different constraints.

For this reason, I think we should change the data structure exposed by this library to expose these routes. Before this change, this library will only report the most recently registered routes and completely omit previously registered ones.

Instead of 

```js
{
  "/foo/bar": {
      "GET": { ... },
      "POST": { ... },
   },
  "/hello": {
      "GET": { ... },
   },
}
```

this PR switches us to use an array of route options for each URL:

```js
{
  "/foo/bar": [
      { ... },
      { ... },
   ],
  "/hello": [
      { ... },
   ],
}
```

I think this is still useful in that you can get to the routes you want quickly, but supports reporting all the routes registered and is a bit more future proof.

Also important is that there are new route options that this library omits. I think it'd be more useful to report all the route options like `constraints` (which is built into fastify) or `websocket` (from `fastify-websocket`). For this reason, I think we should capture the whole route options object fastify sends to the `onRoute` hook. That way, downstream consumers of the route map have access to the most information possible.

And finally, I think that using the raw `routeOptions` object from fastify allows subsequent `onRoute` hooks to modify the route options. Before this change, if this plugin was registered first and then a `onRoute` hook was registered after, changes that second hook made to the route options wouldn't be captured. Using the raw object without copying allows this plugin to reflect changes made by subsequent hooks.

This is for sure a breaking change, so if y'all are ok with this direction I will add a changelog entry to explain how to upgrade.

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
