### PR TITLE
fix: migrate from tap to node:test and c8

### DIFF
--- a/.taprc
+++ b/.taprc
@@ -1,2 +1,0 @@
-files:
-  - test/**/*.test.js

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "lint": "standard | snazzy",
     "test": "npm run test:unit && npm run test:typescript",
-    "test:unit": "c8 node --test",
+    "test:unit": "c8 --100 node --test",
     "test:typescript": "tsd"
   },
   "precommit": [

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "lint": "standard | snazzy",
     "test": "npm run test:unit && npm run test:typescript",
-    "test:unit": "tap",
+    "test:unit": "c8 node --test",
     "test:typescript": "tsd"
   },
   "precommit": [
@@ -31,10 +31,10 @@
   "devDependencies": {
     "@fastify/pre-commit": "^2.1.0",
     "@types/node": "^22.0.0",
+    "c8": "^10.1.2",
     "fastify": "^5.0.0-alpha.3",
     "snazzy": "^9.0.0",
     "standard": "^17.1.0",
-    "tap": "^20.0.1",
     "tsd": "^0.31.1"
   },
   "dependencies": {

--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const test = require('tap').test
+const { test } = require('node:test')
 const Fastify = require('fastify')
 const plugin = require('..')
 
@@ -32,10 +32,14 @@ const routeA = function (fastify, opts, next) {
 }
 
 const routeB = function (fastify, opts, next) {
-  fastify.post('/hello/:world', {
-    bodyLimit: 2000,
-    logLevel: 'info'
-  }, handler)
+  fastify.post(
+    '/hello/:world',
+    {
+      bodyLimit: 2000,
+      logLevel: 'info'
+    },
+    handler
+  )
 
   next()
 }
@@ -69,24 +73,56 @@ test('should correctly map routes', async (t) => {
 
   await fastify.ready()
 
-  t.equal(fastify.routes.get('/v1/hello/:world')[0].method, 'GET')
-  t.equal(fastify.routes.get('/v1/hello/:world')[0].url, '/v1/hello/:world')
-  t.equal(fastify.routes.get('/v1/hello/:world')[0].logLevel, 'warn')
-  t.equal(fastify.routes.get('/v1/hello/:world')[0].prefix, '/v1')
-  t.equal(fastify.routes.get('/v1/hello/:world')[0].bodyLimit, 1000)
-  t.equal(fastify.routes.get('/v1/hello/:world')[0].handler, handler)
-  t.same(fastify.routes.get('/v1/hello/:world')[0].schema, schema)
+  t.assert.strictEqual(fastify.routes.get('/v1/hello/:world')[0].method, 'GET')
+  t.assert.strictEqual(
+    fastify.routes.get('/v1/hello/:world')[0].url,
+    '/v1/hello/:world'
+  )
+  t.assert.strictEqual(
+    fastify.routes.get('/v1/hello/:world')[0].logLevel,
+    'warn'
+  )
+  t.assert.strictEqual(fastify.routes.get('/v1/hello/:world')[0].prefix, '/v1')
+  t.assert.strictEqual(
+    fastify.routes.get('/v1/hello/:world')[0].bodyLimit,
+    1000
+  )
+  t.assert.strictEqual(
+    fastify.routes.get('/v1/hello/:world')[0].handler,
+    handler
+  )
+  t.assert.deepStrictEqual(
+    fastify.routes.get('/v1/hello/:world')[0].schema,
+    schema
+  )
 
-  t.equal(fastify.routes.get('/v1/hello/:world')[1].method, 'POST')
-  t.equal(fastify.routes.get('/v1/hello/:world')[1].url, '/v1/hello/:world')
-  t.equal(fastify.routes.get('/v1/hello/:world')[1].logLevel, 'info')
-  t.equal(fastify.routes.get('/v1/hello/:world')[1].prefix, '/v1')
-  t.equal(fastify.routes.get('/v1/hello/:world')[1].bodyLimit, 2000)
-  t.equal(fastify.routes.get('/v1/hello/:world')[1].handler, handler)
+  t.assert.strictEqual(fastify.routes.get('/v1/hello/:world')[1].method, 'POST')
+  t.assert.strictEqual(
+    fastify.routes.get('/v1/hello/:world')[1].url,
+    '/v1/hello/:world'
+  )
+  t.assert.strictEqual(
+    fastify.routes.get('/v1/hello/:world')[1].logLevel,
+    'info'
+  )
+  t.assert.strictEqual(fastify.routes.get('/v1/hello/:world')[1].prefix, '/v1')
+  t.assert.strictEqual(
+    fastify.routes.get('/v1/hello/:world')[1].bodyLimit,
+    2000
+  )
+  t.assert.strictEqual(
+    fastify.routes.get('/v1/hello/:world')[1].handler,
+    handler
+  )
 
-  t.same(fastify.routes.get('/foo')[0].method, ['GET', 'HEAD'])
-  t.equal(fastify.routes.get('/foo')[0].constraints, undefined)
-  t.same(fastify.routes.get('/foo')[1].constraints, { host: 'fastify.dev' })
+  t.assert.deepStrictEqual(fastify.routes.get('/foo')[0].method, [
+    'GET',
+    'HEAD'
+  ])
+  t.assert.strictEqual(fastify.routes.get('/foo')[0].constraints, undefined)
+  t.assert.deepStrictEqual(fastify.routes.get('/foo')[1].constraints, {
+    host: 'fastify.dev'
+  })
 })
 
 test('should allow other later onRoute handlers to change route options', async (t) => {
@@ -100,8 +136,13 @@ test('should allow other later onRoute handlers to change route options', async 
 
   await fastify.ready()
 
-  t.equal(fastify.routes.get('/hello/:world')[0].url, '/hello/:world')
-  t.same(fastify.routes.get('/hello/:world')[0].constraints, { host: 'some-automatic-constraint.com' })
+  t.assert.strictEqual(
+    fastify.routes.get('/hello/:world')[0].url,
+    '/hello/:world'
+  )
+  t.assert.deepStrictEqual(fastify.routes.get('/hello/:world')[0].constraints, {
+    host: 'some-automatic-constraint.com'
+  })
 })
 
 test('should correctly map routes with automatic HEAD routes', async (t) => {
@@ -116,30 +157,77 @@ test('should correctly map routes with automatic HEAD routes', async (t) => {
 
   await fastify.ready()
 
-  t.equal(fastify.routes.get('/v1/hello/:world')[0].method, 'GET')
-  t.equal(fastify.routes.get('/v1/hello/:world')[0].url, '/v1/hello/:world')
-  t.equal(fastify.routes.get('/v1/hello/:world')[0].logLevel, 'warn')
-  t.equal(fastify.routes.get('/v1/hello/:world')[0].prefix, '/v1')
-  t.equal(fastify.routes.get('/v1/hello/:world')[0].bodyLimit, 1000)
-  t.equal(fastify.routes.get('/v1/hello/:world')[0].handler, handler)
-  t.same(fastify.routes.get('/v1/hello/:world')[0].schema, schema)
+  t.assert.strictEqual(fastify.routes.get('/v1/hello/:world')[0].method, 'GET')
+  t.assert.strictEqual(
+    fastify.routes.get('/v1/hello/:world')[0].url,
+    '/v1/hello/:world'
+  )
+  t.assert.strictEqual(
+    fastify.routes.get('/v1/hello/:world')[0].logLevel,
+    'warn'
+  )
+  t.assert.strictEqual(fastify.routes.get('/v1/hello/:world')[0].prefix, '/v1')
+  t.assert.strictEqual(
+    fastify.routes.get('/v1/hello/:world')[0].bodyLimit,
+    1000
+  )
+  t.assert.strictEqual(
+    fastify.routes.get('/v1/hello/:world')[0].handler,
+    handler
+  )
+  t.assert.deepStrictEqual(
+    fastify.routes.get('/v1/hello/:world')[0].schema,
+    schema
+  )
 
-  t.equal(fastify.routes.get('/v1/hello/:world')[1].method, 'HEAD')
-  t.equal(fastify.routes.get('/v1/hello/:world')[1].url, '/v1/hello/:world')
-  t.equal(fastify.routes.get('/v1/hello/:world')[1].logLevel, 'warn')
-  t.equal(fastify.routes.get('/v1/hello/:world')[1].prefix, '/v1')
-  t.equal(fastify.routes.get('/v1/hello/:world')[1].bodyLimit, 1000)
-  t.equal(fastify.routes.get('/v1/hello/:world')[1].handler, handler)
-  t.same(fastify.routes.get('/v1/hello/:world')[1].schema, schema)
+  t.assert.strictEqual(fastify.routes.get('/v1/hello/:world')[1].method, 'HEAD')
+  t.assert.strictEqual(
+    fastify.routes.get('/v1/hello/:world')[1].url,
+    '/v1/hello/:world'
+  )
+  t.assert.strictEqual(
+    fastify.routes.get('/v1/hello/:world')[1].logLevel,
+    'warn'
+  )
+  t.assert.strictEqual(fastify.routes.get('/v1/hello/:world')[1].prefix, '/v1')
+  t.assert.strictEqual(
+    fastify.routes.get('/v1/hello/:world')[1].bodyLimit,
+    1000
+  )
+  t.assert.strictEqual(
+    fastify.routes.get('/v1/hello/:world')[1].handler,
+    handler
+  )
+  t.assert.deepStrictEqual(
+    fastify.routes.get('/v1/hello/:world')[1].schema,
+    schema
+  )
 
-  t.equal(fastify.routes.get('/v1/hello/:world')[2].method, 'POST')
-  t.equal(fastify.routes.get('/v1/hello/:world')[2].url, '/v1/hello/:world')
-  t.equal(fastify.routes.get('/v1/hello/:world')[2].logLevel, 'info')
-  t.equal(fastify.routes.get('/v1/hello/:world')[2].prefix, '/v1')
-  t.equal(fastify.routes.get('/v1/hello/:world')[2].bodyLimit, 2000)
-  t.equal(fastify.routes.get('/v1/hello/:world')[2].handler, handler)
+  t.assert.strictEqual(fastify.routes.get('/v1/hello/:world')[2].method, 'POST')
+  t.assert.strictEqual(
+    fastify.routes.get('/v1/hello/:world')[2].url,
+    '/v1/hello/:world'
+  )
+  t.assert.strictEqual(
+    fastify.routes.get('/v1/hello/:world')[2].logLevel,
+    'info'
+  )
+  t.assert.strictEqual(fastify.routes.get('/v1/hello/:world')[2].prefix, '/v1')
+  t.assert.strictEqual(
+    fastify.routes.get('/v1/hello/:world')[2].bodyLimit,
+    2000
+  )
+  t.assert.strictEqual(
+    fastify.routes.get('/v1/hello/:world')[2].handler,
+    handler
+  )
 
-  t.same(fastify.routes.get('/foo')[0].method, ['GET', 'HEAD'])
-  t.equal(fastify.routes.get('/foo')[0].constraints, undefined)
-  t.same(fastify.routes.get('/foo')[1].constraints, { host: 'fastify.dev' })
+  t.assert.deepStrictEqual(fastify.routes.get('/foo')[0].method, [
+    'GET',
+    'HEAD'
+  ])
+  t.assert.strictEqual(fastify.routes.get('/foo')[0].constraints, undefined)
+  t.assert.deepStrictEqual(fastify.routes.get('/foo')[1].constraints, {
+    host: 'fastify.dev'
+  })
 })


### PR DESCRIPTION
#### Checklist

This PR removes `tap` and uses `node:test` and. `c8`

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
