### PR TITLE
docs(readme): update ci badge syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # @fastify/routes
 
-![CI](https://github.com/fastify/fastify-routes/workflows/CI/badge.svg)
+[![CI](https://github.com/fastify/fastify-routes/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/fastify/fastify-routes/actions/workflows/ci.yml)
 [![NPM version](https://img.shields.io/npm/v/@fastify/routes.svg?style=flat)](https://www.npmjs.com/package/@fastify/routes)
 [![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)](https://standardjs.com/)
 


### PR DESCRIPTION
Syntax has changed, see https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/monitoring-workflows/adding-a-workflow-status-badge